### PR TITLE
fix: 解决ios18播放视频没有关闭入口问题

### DIFF
--- a/ios/Classes/OpenFilePlugin.m
+++ b/ios/Classes/OpenFilePlugin.m
@@ -103,6 +103,9 @@ TopViewControllerForViewController(UIViewController *viewController) {
             }
             @try {
                 BOOL previewSucceeded = [_documentController presentPreviewAnimated:YES];
+                if (@available(iOS 18.0, *)) {
+                    sleep(1);
+                }
                 if(!previewSucceeded){
                     UIViewController *rootViewController = RootViewController();
                     UIViewController *viewController =


### PR DESCRIPTION
在ios18上受动画影响，导致导航栏不显示，播放页面无法正常关闭。
1、添加延时解决
2、关闭动画(第一次点击还是无导航栏)