### PR TITLE
Clean up AndroidManifest.xml by removing redundant package declaration

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.crazecoder.openfile">
+    xmlns:tools="http://schemas.android.com/tools">
     
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"


### PR DESCRIPTION
This PR removes the deprecated `package` attribute from AndroidManifest.xml. Starting with Android Gradle Plugin 7.0.0, the `package` attribute in the manifest has been deprecated in favor of the `namespace` property in build.gradle.

### Changes made:
- Removed the `package="com.crazecoder.openfile"` attribute from the manifest

### Benefits:
- Aligns with modern Android development practices
- Reduces potential conflicts between manifest package and Gradle namespace

